### PR TITLE
i18n: fav -> favorite

### DIFF
--- a/app/qml/action/SubAction.qml
+++ b/app/qml/action/SubAction.qml
@@ -11,7 +11,7 @@ Action {
     property QtObject querier: null
 
     icon.name: liked ? MD.Token.icon.done : MD.Token.icon.add
-    text: qsTr(liked ? 'fav-ed' : 'fav')
+    text: qsTr(liked ? 'favorited' : 'favorite')
     onTriggered: {
         querier.sub = !liked;
         querier.itemId = root.itemId;


### PR DESCRIPTION
IMO it's inappropriate to use "fav-ed" as an abbreviation of "favorited".
According to [Collins](https://www.collinsdictionary.com/dictionary/english/favourite), "favorite" can be used as a verb, so we can use "favorited" use represent the state of in favorite playlists.