### PR TITLE
fix: build against Qt 6.8

### DIFF
--- a/core/include/core/qstr_helper.h
+++ b/core/include/core/qstr_helper.h
@@ -44,8 +44,3 @@ struct fmt::formatter<QStringView> : fmt::formatter<std::string> {
         return fmt::formatter<std::string>::format(qs.toString().toStdString(), ctx);
     }
 };
-
-inline std::strong_ordering operator<=>(const QString& a, const QString& b) {
-    return a < b ? std::strong_ordering::less
-                 : (a == b ? std::strong_ordering::equal : std::strong_ordering::greater);
-}


### PR DESCRIPTION
- When building against Qt 6.8, the following error occurs:
```
In file included from /build/qcm/src/Qcm/qcm_interface/item_id.cpp:3:
/build/qcm/src/Qcm/core/include/core/qstr_helper.h:48:29: error: redefinition of ‘std::strong_ordering operator<=>(const QString&, const QString&)’
   48 | inline std::strong_ordering operator<=>(const QString& a, const QString& b) {
      |                             ^~~~~~~~
In file included from /usr/include/qt6/QtCore/qglobal.h:63,
                 from /usr/include/qt6/QtCore/qnamespace.h:12,
                 from /usr/include/qt6/QtCore/qobjectdefs.h:12,
                 from /usr/include/qt6/QtCore/qobject.h:10,
                 from /usr/include/qt6/QtCore/QObject:1,
                 from /build/qcm/src/Qcm/qcm_interface/include/qcm_interface/item_id.h:3,
                 from /build/qcm/src/Qcm/qcm_interface/item_id.cpp:1:
/usr/include/qt6/QtCore/qstring.h:777:5: note: ‘std::strong_ordering operator<=>(const QString&, const QString&)’ previously defined here
  777 |     Q_DECLARE_STRONGLY_ORDERED(QString)
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

- According to [What's New in Qt 6.8](https://doc.qt.io/qt-6/whatsnew68.html#qt-core-module), More [QtCore](https://doc.qt.io/qt-6/qtcore-module.html) types with operator<() now also support `operator<=>()` when compiled with C++20 (and `compareThreeWay()` even for C++17).