### PR TITLE
refactor: replace deprecated _qs with _s from Qt::StringLiterals

### DIFF
--- a/mpris/mediaplayer2.cpp
+++ b/mpris/mediaplayer2.cpp
@@ -8,13 +8,14 @@
 #include <QUrl>
 
 using namespace mpris;
+using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
-static const QString MprisObjectPath { u"/org/mpris/MediaPlayer2"_qs };
-static const QString MprisPlayerObjectPath { u"/org/mpris/MediaPlayer2.Player"_qs };
-static const QString DBusPropertiesInterface { u"org.freedesktop.DBus.Properties"_qs };
-static const QString DBusPropertiesChangedSignal { u"PropertiesChanged"_qs };
+static const QString MprisObjectPath { u"/org/mpris/MediaPlayer2"_s };
+static const QString MprisPlayerObjectPath { u"/org/mpris/MediaPlayer2.Player"_s };
+static const QString DBusPropertiesInterface { u"org.freedesktop.DBus.Properties"_s };
+static const QString DBusPropertiesChangedSignal { u"PropertiesChanged"_s };
 } // namespace
 
 MediaPlayer2::MediaPlayer2(QObject* parent)

--- a/mpris/mpris.cpp
+++ b/mpris/mpris.cpp
@@ -4,10 +4,11 @@
 #include <QDBusConnection>
 
 using namespace mpris;
+using namespace Qt::Literals::StringLiterals;
 
 namespace
 {
-static const QString ServiceNamePrefix { u"org.mpris.MediaPlayer2."_qs };
+static const QString ServiceNamePrefix { u"org.mpris.MediaPlayer2."_s };
 }
 
 Mpris::Mpris(QObject* parent): QObject(parent), m_mp(new MediaPlayer2(this)) {};


### PR DESCRIPTION
- [`QtLiterals::operator""_qs`](https://doc.qt.io/qt-6/qtliterals-obsolete.html#operator-22-22_qs) has been deprecated in Qt 6.8.