### PR TITLE
[cmake] fix build failure

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -41,7 +41,7 @@ set(Random_BuildTests OFF)
 FetchContent_Declare(
   random
   GIT_REPOSITORY https://github.com/ilqvya/random.git
-  GIT_TAG 041302cdb6668c1f6b09e803b6c9bda8e3820fdc
+  GIT_COMMIT 041302cdb6668c1f6b09e803b6c9bda8e3820fdc
   GIT_SHALLOW 1
   GIT_PROGRESS 1
   EXCLUDE_FROM_ALL)
@@ -57,7 +57,7 @@ set(KDSingleApplication_DOCS OFF)
 FetchContent_Declare(
   KDSingleApplication
   GIT_REPOSITORY https://github.com/KDAB/KDSingleApplication.git
-  GIT_TAG 631237acd4e20251c7f702db5e5434c83f0e336d
+  GIT_COMMIT 631237acd4e20251c7f702db5e5434c83f0e336d
   GIT_SHALLOW 1
   GIT_PROGRESS 1
   SYSTEM EXCLUDE_FROM_ALL FIND_PACKAGE_ARGS QUIET GLOBAL)
@@ -97,7 +97,7 @@ FetchContent_Declare(
   ctre
   GIT_REPOSITORY
     https://github.com/hanickadot/compile-time-regular-expressions.git
-  GIT_TAG e0f36500bc941fe447718ab625490728790c933f
+  GIT_COMMIT e0f36500bc941fe447718ab625490728790c933f
   GIT_SHALLOW 1
   GIT_PROGRESS 1
   EXCLUDE_FROM_ALL FIND_PACKAGE_ARGS 3.9.0 GLOBAL)
@@ -126,7 +126,7 @@ endif()
 FetchContent_Declare(
   ncrequest
   GIT_REPOSITORY https://github.com/hypengw/ncrequest.git
-  GIT_TAG 63fc742909d67651967f373184bdc414efff713a
+  GIT_COMMIT 63fc742909d67651967f373184bdc414efff713a
   GIT_SHALLOW 1
   GIT_PROGRESS 1
   EXCLUDE_FROM_ALL)


### PR DESCRIPTION
When building from `master`, the following error occurs:
```
fatal: unable to read tree (041302cdb6668c1f6b09e803b6c9bda8e3820fdc)
CMake Error at random-subbuild/random-populate-prefix/tmp/random-populate-gitclone.cmake:61 (message):
  Failed to checkout tag: '041302cdb6668c1f6b09e803b6c9bda8e3820fdc'


FAILED: random-populate-prefix/src/random-populate-stamp/random-populate-download /build/qcm-git/src/build/_deps/random-subbuild/random-populate-prefix/src/random-populate-stamp/random-populate-download 
cd /build/qcm-git/src/build/_deps && /usr/bin/cmake -DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE -P /build/qcm-git/src/build/_deps/random-subbuild/random-populate-prefix/tmp/random-populate-gitclone.cmake && /usr/bin/cmake -E touch /build/qcm-git/src/build/_deps/random-subbuild/random-populate-prefix/src/random-populate-stamp/random-populate-download
ninja: build stopped: subcommand failed.

CMake Error at /usr/share/cmake/Modules/FetchContent.cmake:1918 (message):
  Build step for random failed: 1
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FetchContent.cmake:1609 (__FetchContent_populateSubbuild)
  /usr/share/cmake/Modules/FetchContent.cmake:2145:EVAL:2 (__FetchContent_doPopulation)
  /usr/share/cmake/Modules/FetchContent.cmake:2145 (cmake_language)
  /usr/share/cmake/Modules/FetchContent.cmake:2384 (__FetchContent_Populate)
  third_party/CMakeLists.txt:48 (FetchContent_MakeAvailable)


-- Configuring incomplete, errors occurred!
```
This pull request fixes the CMake error.